### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,4 +31,4 @@ interface TestOperation<T> extends BaseOperation {
  * @param {Array} patch Your input patch
  * @returns {Array} The squash patch
  */
-export function squash<T>(patch: Operation[]): Operation[];
+export default function squash<T>(patch: Operation[]): Operation[];


### PR DESCRIPTION
Hello 👋 

When using this package in a TS project, and importing with the default import syntax:
```
import squash from 'json-squash';
```

The result is a TS error:
```
This expression is not callable.
  Type 'typeof import(".../node_modules/json-squash/index")' has no call signatures.ts(2349)
```

This change proposes to export `squash` type definition in `index.d.ts` as a default export to remove the error.